### PR TITLE
Latest PR comment options

### DIFF
--- a/test/test7.tf
+++ b/test/test7.tf
@@ -1,0 +1,35 @@
+provider "aws" {
+  region = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id = true
+  access_key = "mock_access_key"
+  secret_key = "mock_secret_key"
+}
+
+resource "aws_instance" "my_web_app" {
+  ami = "ami-005e54dee72cc1d00"
+
+  instance_type = "m3.xlarge" # <<<<<<<<<< Try changing this to m5.xlarge to compare the costs
+
+  tags = {
+    Environment = "production"
+    Service = "web-app"
+  }
+
+  root_block_device {
+    volume_size = 1000 # <<<<<<<<<< Try adding volume_type="gp3" to compare costs
+  }
+}
+
+resource "aws_lambda_function" "my_hello_world" {
+  runtime = "nodejs12.x"
+  handler = "exports.test"
+  image_uri = "test"
+  function_name = "test"
+  role = "arn:aws:ec2:us-east-1:123123123123:instance/i-1231231231"
+
+  memory_size = 512
+  tags = {
+    Environment = "Prod"
+  }
+}


### PR DESCRIPTION
[//]: <> (ghapp-comment, valid-at=2024-02-26T15:09:57Z)

<h3>Current comment</h3>
<h4>💰 Monthly cost will increase by $294 📈</h4>
<table>
  <thead>
    <td>Project</td>
    <td>Cost change</td>
    <td>New monthly cost</td>
  </thead>
  <tbody>
    <tr>
      <td>infra</td>
      <td>+$294</td>
      <td align="right">$294</td>
    </tr>
    <tr>
      <td>app</td>
      <td>+$294</td>
      <td align="right">$294</td>
    </tr>
  </tbody>
</table>
<details>
<summary>Cost details</summary>

```
──────────────────────────────────
Project: test
Module path: test

+ aws_instance.my_web_app
  +$294

    + Instance usage (Linux/UNIX, on-demand, m3.xlarge)
      +$194

    + root_block_device
    
        + Storage (general purpose SSD, gp2)
          +$100

+ aws_lambda_function.my_hello_world
  Monthly cost depends on usage

    + Requests
      Monthly cost depends on usage
        +$0.20 per 1M requests

    + Ephemeral storage
      Monthly cost depends on usage
        +$0.0000000309 per GB-seconds

    + Duration (first 6B)
      Monthly cost depends on usage
        +$0.0000166667 per GB-seconds

Monthly cost change for test (Module path: test)
Amount:  +$294 ($0.00 → $294)

──────────────────────────────────
Key: ~ changed, + added, - removed

2 cloud resources were detected:
∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

Infracost estimate: Monthly cost will increase by $294 ↑
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
┃ Project                                            ┃ Cost change ┃ New monthly cost ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━┫
┃ test                                               ┃       +$294 ┃ $294             ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━┛
```
</details>

<h4>Governance checks</h4>

<details>
<summary><strong>🔴 5 failures</strong></summary>
<br />
<table>
<tr><td><strong>EBS - consider upgrading gp2 volumes to gp3</strong>: gp3 volumes are the latest generation of general-purpose SSD-based EBS volumes that enable you to provision performance independent of storage capacity, while providing up to **20% lower price per GB** than existing gp2 volumes. With gp3 volumes, you can scale IOPS (input/output operations per second) and throughput without needing to provision additional block storage capacity. This means you only pay for the storage you need.</td></tr>
<tr><td>

aws_instance.my_web_app at `test/test7.tf:9`
* Set `root_block_device.volume_type` to `gp3`.

in project `test`

</td></tr>
</table>
<table>
<tr><td><strong>EC2 - consider using latest generation instances for m family instances</strong>: Upgrade to the Amazon EC2 m5 instance family to get a higher performing CPU with support for AVX-512 instructions, up to 384 GiB of RAM, and up to 25 Gbps of networking bandwidth, all at a lower price point than previous generation instances. For example an `m3.large` instance with 7.5 GiB of memory and 2 vCPUs has a monthly cost of $97. Whereas a `m5.large` instance with 8 GiB of memory and 2 vCPUs costs just $70. That's a 27% saving for a more performant machine.</td></tr>
<tr><td>

aws_instance.my_web_app at `test/test7.tf:9`
* Switch `instance_type` from `m3.xlarge` to `m5.xlarge`

in project `test`

</td></tr>
</table>
<table>
<tr><td><strong>FinOps tags</strong>: This example Tagging policy shows how you can enforce required FinOps tag keys/values in pull requests. This example checks for the tags 'Service' (can have any value) and 'Environment' (must be Dev/Stage/Prod) on all taggable resources being changed in the pull request. You can adjust it from https://dashboard.infracost.io > Governance > Tagging policies. You have a 14 day trial of this feature as it's part of Infracost Cloud.</td></tr>
<tr><td>

aws_instance.my_web_app at `test/test7.tf:9`
* `Environment` has invalid value `production`. Must be one of `Dev`, `Stage`, `Prod`
* Missing mandatory tags: `root_block_device.Service`, `root_block_device.Environment`

in project `test`

</td></tr>
<tr><td>

aws_lambda_function.my_hello_world at `test/test7.tf:24`
* Missing mandatory tags: `Service`

in project `test`

</td></tr>
</table>
<table>
<tr><td><strong>Example threshold warning</strong></td></tr>
<tr><td>

At least one project exceeded per-project threshold. Cost increased by $294, threshold was $10. This example Guardrail shows how you can monitor pull request costs, and trigger actions when your defined thresholds are exceeded. You can adjust it from https://dashboard.infracost.io > Governance > Guardrails. You have a 14 day trial of this feature as it's part of Infracost Cloud.
</td></tr>
</table>
<table>
<tr><td><strong>Change increases costs by more than $1.2K/yr - review</strong></td></tr>
<tr><td>

Cost increased by $294, threshold was $100. This change increases costs by more than $1.2K/yr, you might want to review it with your team lead.
</td></tr>
</table>
</details>

<details>
<summary><strong>🟢 46 passed</strong></summary>
<br />
<table>
<tr><td>46 FinOps policies, 0 Tagging policies, and 0 Guardrails passed.</td></tr>
</table>
</details>

<sub><a href="https://dashboard.infracost.io/org/cicd-test/repos/c71ca8e1-164b-4792-a3e7-987898ce6cdd/runs/030b3b47-89fa-4e14-a4e5-be54e8273ca5" rel="noopener noreferrer" target="_blank">View in Infracost Cloud. </a>This comment will be updated when code changes.
</sub>
