### PR TITLE
PR comment options

### DIFF
--- a/test9.tf
+++ b/test9.tf
@@ -1,0 +1,35 @@
+provider "aws" {
+  region = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id = true
+  access_key = "mock_access_key"
+  secret_key = "mock_secret_key"
+}
+
+resource "aws_instance" "my_web_app" {
+  ami = "ami-005e54dee72cc1d00"
+
+  instance_type = "m3.xlarge" # <<<<<<<<<< Try changing this to m5.xlarge to compare the costs
+
+  tags = {
+    Environment = "production"
+    Service = "web-app"
+  }
+
+  root_block_device {
+    volume_size = 1000 # <<<<<<<<<< Try adding volume_type="gp3" to compare costs
+  }
+}
+
+resource "aws_lambda_function" "my_hello_world" {
+  runtime = "nodejs12.x"
+  handler = "exports.test"
+  image_uri = "test"
+  function_name = "test"
+  role = "arn:aws:ec2:us-east-1:123123123123:instance/i-1231231231"
+
+  memory_size = 512
+  tags = {
+    Environment = "Prod"
+  }
+}


### PR DESCRIPTION
[//]: <> (infracost-ghapp-comment, valid-at=2023-12-15T18:59:45Z)

## Option 0 - split fixed & variable costs (👉 see [existing PR comment](https://github.com/alikhajeh1/example-terraform/pull/4#issuecomment-1748989294) to compare)
<h3>Cost checks</h3>

#### 📉 Monthly [fixed costs](https://gist.github.com/alikhajeh1/7b3c0c88fa9f2aee35da6e344b46fe35 "Fixed costs are consistent charges for provisioned resources, like the hourly cost for a virtual machine, which stays constant no matter how much it is used. Infracost estimates these resources assuming they are used for the whole month (730 hours).") will decrease by $1,393 and [variable costs](https://gist.github.com/alikhajeh1/7b3c0c88fa9f2aee35da6e344b46fe35 "Variable costs are charges based on actual usage, like the storage costs for an object storage bucket. Infracost estimates these resources using the monthly usage values in the usage-file.") will decrease by $300

<b>💰 This pull request also has:</b>

- S3 lifecycle policy changes that may decrease costs</br>
- CloudWatch retention policy changes that may decrease costs

<table>
  <thead>
    <td>Changed project</td>
    <td>Fixed costs</td>
    <td>Variable costs</td>
  </thead>
  <tbody>
    <tr>
      <td>infra</td>
      <td>-$481 (-71%)</td>
      <td align="right">-$180 (-20%)</td>
    </tr>
    <tr>
      <td>app</td>
      <td>-$912 (-14%)</td>
      <td align="right">-$120 (-5%)</td>
    </tr>
  </tbody>
</table>
- Variable costs were estimated using <a href="https://github.com/infracost/infracost/blob/master/infracost-usage-example.yml">the default usage-file</a></br>
- Unsupported resources and three projects with errors were skipped. Refer to cost details for more information.</br></br>

<details>
<summary> <b>Cost details</b></summary>

```
Key: ~ changed, + added, - removed

Project: infra
- aws_instance.my_web_app, -$135:
  ⮑ Fixed costs:
    ⮑ Instance usage (Linux/UNIX, on-demand, m3.xlarge -> m5.xlarge): 
       Monthly Qty: 730 hours 
       Monthly Cost: -$100 ($200 → $100)
    ⮑ Storage (general purpose SSD, gp2 -> gp3):
       Monthly Qty: 1,000GB
       Monthly Cost: -$35 ($135 → $100)

- aws_cloudwatch_log_group.logging, -$105:
  ⮑ Variable costs:
    ⮑ Insights queries data scanned:
       Monthly Qty: 1,000GB 
       Monthly Cost: -$80 ($180 → $80)
    ⮑ Data ingested: 
       Monthly Qty: 100GB
       Monthly Cost: -$40 ($90 → $50)
    ⮑ Archival Storage:
       Monthly Qty: 100GB
       Monthly Cost: -$10 ($90 → $80)

──────────────────────────────────

Errored projects that were skipped:
Project A, Project B, Project C 

──────────────────────────────────

Unsupported resources:
- 4 possibly paid resources of type: aws_kms_key, aws_blockchain
- 50 free resources
```
</details>

---

<h3>Governance checks</h3>

<details>
<summary><strong>🔴 3 failures</strong></summary>
<br />
<table>
<tr><td><strong>FinOps tags</strong>: FinOps tags are critical in enabling us to create showback reports, track budgets and optimize our costs. Please email finops@acme.org if you need assistance.</td></tr>
<tr><td>

aws_instance.web_app at `main.tf:9`
* `Environment` has invalid value `production`. Must be one of `Dev`, `Stage`, `Prod`
* Missing mandatory tags: `root_block_device.Service`, `root_block_device.Environment`

in project `aws`

</tr></td>
</table>
<table>
<tr><td><strong>EBS - consider upgrading gp2 volumes to gp3</strong>: gp3 volumes are the latest generation of general-purpose SSD-based EBS volumes that enable you to provision performance independent of storage capacity, while providing up to 20% lower price per GB than existing gp2 volumes. With gp3 volumes, you can scale IOPS (input/output operations per second) and throughput without needing to provision additional block storage capacity. This means you only pay for the storage you need.</td></tr>
<tr><td>

aws_instance.web_app at `main.tf:9`
* Set `root_block_device.volume_type` to `gp3`.

in project `aws`

</tr></td>
</table>
<table>
<tr><td><strong>EC2 - consider using latest generation instances for m family instances</strong>: Upgrade to the Amazon EC2 m5 instance family to get a higher performing CPU with support for AVX-512 instructions, up to 384 GiB of RAM, and up to 25 Gbps of networking bandwidth, all at a lower price point than previous generation instances. For example an `m3.large` instance with 7.5 GiB of memory and 2 vCPUs has a monthly cost of $97. Whereas a `m5.large` instance with 8 GiB of memory and 2 vCPUs costs just $70. That's a 27% saving for a more performant machine.</td></tr>
<tr><td>

aws_instance.web_app at `main.tf:9`
* Switch `instance_type` from `m3.xlarge` to `m5.xlarge`

in project `aws`

</tr></td>
</table>
</details>

<details>
<summary><strong>🟢 47 passed</strong></summary>
<br />
<table>
<tr><td>46 FinOps policies, 0 Tagging policies, and 1 Guardrail passed.</td></tr>
</table>
</details>

There are also [143 pre-existing issues](a) in this repo. Fix some to climb your [org’s leaderboard](b) 🥇

---
<sub><a href="https://dashboard.infracost.io/org/test-ihiif/repos/1e70f3e5-88e9-41a5-8a8c-45ca769b7deb/runs/cc4417a0-d41b-4d48-bae7-74383c04a178" rel="noopener noreferrer" target="_blank">View report in Infracost Cloud</a>. This comment will be updated when code changes.</sub>
