### PR TITLE
Migrate to Graviton - $5.2K/yr savings

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -18,6 +18,7 @@ resource "aws_instance" "my_web_app" {
 
   root_block_device {
     volume_size = 1000
+    volume_type = "gp3"
   }
 }
 


### PR DESCRIPTION
💰 Infracost opened this pull request as part of the following campaign:

<table>
    <tr>
      <td>
        <details><summary><b>Policy:</b> AWS ECS - consider using Graviton instances</summary>
gp3 volumes are the latest generation of general-purpose SSD-based EBS volumes that enable you to provision performance independent of storage capacity, while providing <b>up to 20% lower price per GB</b> than existing gp2 volumes. With gp3 volumes, you can scale IOPS (input/output operations per second) and throughput without needing to provision additional block storage capacity. This means you only pay for the storage you need.
        </details>
      </td>
      <td><b>Potential savings:</b> $5,200/yr</td>
 <tr>
 <tr>
<td colSpan="2">
       <details>
          <summary><b>Risk:</b> Medium</summary>
Container images may not be compatible with ARM64.
        </details>
      </td>
    </tr>
<tr>
      <td colspan="2">
        <details>
          <summary><b>Deployment details:</b> no downtime expected, see <a href="https://aws.amazon.com/awstv/watch/1cb0eb0a589/">AWS docs</a> for details</summary>
          ECS rolls out new task revisions in a blue/green or rolling‑update fashion without interrupting service. For ECS tasks that run on EC2, you'll need to ensure your cluster has a Graviton‑enabled capacity provider attached before deployment.
        </details>
      </td>
    </tr>
</table>

Next steps:
✅ Deploy this change before the campaign deadline: <b>June 31</b>
💬 Doesn't apply? Close the PR with a comment
🛠️ Needs changes? Check out the branch to rebase or adjust